### PR TITLE
Remove VERSION. Ensure that we pull PostgreSQL DB v12 database.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '2'
 services:
   db:
-    image: postgres
+    image: postgres:12
     container_name: db
     volumes:
       - onto-pg-data:/var/lib/postgresql/data


### PR DESCRIPTION
1. Docker complains:  "Version" is no longer required and should be removed to avoid confusion"
2. Ensure a v12 PostgreSQL DB image is pulled, otherwise the DB container fails with an error, and then then the OntoServer application complains that it cannot connect to the DB successfully.