### PR TITLE
ci: lint charts with chart-testing (ct)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,38 @@ env:
   # Must match the version the helm-readme-generator skill uses, or the drift check below
   # will disagree with locally generated tables.
   README_GENERATOR_VERSION: 2.7.2
+  # Pinned so a new ct release cannot introduce yamllint/yamale rules that fail CI on
+  # unchanged charts. Bump deliberately, and re-run `ct lint --config ct.yaml` locally first.
+  CT_VERSION: 3.14.0
 
 jobs:
+  # chart-testing adds what `helm lint` alone does not: yamllint over Chart.yaml/values.yaml,
+  # yamale schema validation of Chart.yaml, and a check that each maintainer resolves to a real
+  # GitHub account. Config lives in ct.yaml at the repo root so a local run matches this job.
+  chart-testing:
+    name: chart-testing (ct lint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # ct resolves target-branch from git history; a shallow clone has none.
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5.0.1
+        with:
+          version: v3.18.4
+
+      # Also installs the yamllint and yamale that ct shells out to, into a uv-managed venv,
+      # so no separate actions/setup-python step is needed.
+      - name: Install chart-testing
+        uses: helm/chart-testing-action@v2.8.0
+        with:
+          version: ${{ env.CT_VERSION }}
+
+      - name: Run ct lint
+        run: ct lint --config ct.yaml
+
   unit-tests:
     name: Lint and Unit Tests
     runs-on: ubuntu-latest

--- a/charts/ontoserver-extras/values.yaml
+++ b/charts/ontoserver-extras/values.yaml
@@ -150,4 +150,3 @@ collector:
     sendBatchSize: 1000
     ## @param collector.batch.timeout                             Maximum time a span waits before being flushed regardless of batch size. Must not be 0s — that disables the timer entirely, so on a quiet server spans wait indefinitely for the batch to fill.
     timeout: 5s
-

--- a/charts/ontoserver-indexer/values.yaml
+++ b/charts/ontoserver-indexer/values.yaml
@@ -1,4 +1,3 @@
-
 ## @section Image parameters
 
 image:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,28 @@
+# chart-testing (ct) configuration.
+#
+# Kept at the repo root so a local `ct lint` behaves exactly like the CI job in
+# .github/workflows/unit-tests.yml. Run it as:
+#
+#   ct lint --config ct.yaml --all
+#
+chart-dirs:
+  - charts
+
+target-branch: master
+
+# Lint every chart, not just the ones changed against target-branch. There are only three
+# charts, and a shared-template edit in one can break the render of another, which a
+# changed-charts-only run would miss.
+all: true
+
+# Release Please owns every chart `version:`, and under that flow Chart.yaml holds the LAST
+# RELEASED version — it is bumped by the release PR, not by the PR making the change. So a
+# normal feature PR legitimately leaves `version:` untouched and ct's increment check would
+# fail every one of them. See RELEASE.md.
+check-version-increment: false
+
+# `helm lint --strict` is run separately in the same workflow; keep ct's own helm lint strict
+# too so the two cannot disagree about what passes.
+helm-lint-extra-args: --strict
+
+validate-maintainers: true


### PR DESCRIPTION
Adds a `chart-testing (ct lint)` job to the Unit Tests workflow.

ct covers what `helm lint` alone does not:
- yamllint over `Chart.yaml` / `values.yaml`
- yamale schema validation of `Chart.yaml`
- validation that each maintainer resolves to a real GitHub account

Config lives in `ct.yaml` at the repo root so `ct lint --config ct.yaml` locally matches CI.
`check-version-increment` is off because Release Please owns chart versions and `Chart.yaml`
holds the *last released* version, so an ordinary PR legitimately leaves `version:` unchanged.

The first commit removes two stray blank lines that ct's yamllint flagged. Whitespace only,
committed as `chore(charts):` so it produces no release PR and no version bump.

All workflows green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)